### PR TITLE
New npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-connect-proxy-with-headers",
-  "version": "10.4.1",
+  "version": "10.4.2",
   "description": "A simple proxy with headers middleware for gulp-connect",
   "repository": {
     "type": "git",


### PR DESCRIPTION
New npm release to include last commit https://github.com/bborn2/gulp-connect-proxy-with-headers/commit/2586b1215f801a8db1744f2384636fa8879d3bbe
